### PR TITLE
experimental: add shortcuts group to command panel

### DIFF
--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -38,6 +38,7 @@ const makeBreakpointCommand = <CommandName extends string>(
   number: number
 ): Command<CommandName> => ({
   name,
+  hidden: true,
   defaultHotkeys: [`${number}`],
   disableHotkeyOnFormTags: true,
   disableHotkeyOnContentEditable: true,
@@ -109,6 +110,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
 
     {
       name: "cancelCurrentDrag",
+      hidden: true,
       defaultHotkeys: ["escape"],
       // radix check event.defaultPrevented before invoking callbacks
       preventDefault: false,
@@ -350,8 +352,11 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
 
     {
       name: "openCommandPanel",
+      hidden: true,
       defaultHotkeys: ["meta+k", "ctrl+k"],
-      handler: openCommandPanel,
+      handler: () => {
+        openCommandPanel();
+      },
     },
   ],
 });

--- a/apps/builder/app/canvas/shared/commands.ts
+++ b/apps/builder/app/canvas/shared/commands.ts
@@ -23,6 +23,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
   commands: [
     {
       name: "editInstanceText",
+      hidden: true,
       defaultHotkeys: ["enter"],
       // builder invokes command with custom hotkey setup
       disableHotkeyOutsideApp: true,
@@ -56,6 +57,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
 
     {
       name: "escapeSelection",
+      hidden: true,
       defaultHotkeys: ["escape"],
       // reset selection for canvas, but not for the builder
       disableHotkeyOutsideApp: true,

--- a/apps/builder/app/shared/commands-emitter.ts
+++ b/apps/builder/app/shared/commands-emitter.ts
@@ -22,6 +22,10 @@ type CommandMeta<CommandName extends string> = {
    * event behavior is prevented
    **/
   disableHotkeyOnContentEditable?: boolean;
+  /**
+   * hide the command in cmd+k panel
+   */
+  hidden?: boolean;
 };
 
 type CommandHandler = () => void;
@@ -40,7 +44,7 @@ export type Command<CommandName extends string> = CommandMeta<CommandName> & {
 /*
  * expose command metas to synchronize between builder, canvas and plugins
  */
-const $commandMetas = atom(new Map<string, CommandMeta<string>>());
+export const $commandMetas = atom(new Map<string, CommandMeta<string>>());
 clientSyncStore.register("commandMetas", $commandMetas);
 
 // Copied from https://github.com/ai/keyux/blob/main/hotkey.js#L1C1-L2C1

--- a/packages/design-system/src/components/command.tsx
+++ b/packages/design-system/src/components/command.tsx
@@ -157,14 +157,26 @@ const CommandInputField = styled(CommandPrimitive.Input, {
 export const CommandInput = (
   props: ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 ) => {
+  const inputRef = useRef<HTMLInputElement>(null);
   const action = useSelectedAction();
   return (
     <CommandInputContainer>
       <CommandInputIcon />
       <CommandInputField
+        ref={inputRef}
         autoFocus={true}
         placeholder="Type a command or search..."
         {...props}
+        onValueChange={(value) => {
+          // reset scroll whenever search is changed
+          requestAnimationFrame(() => {
+            inputRef.current
+              ?.closest("[cmdk-root]")
+              ?.querySelector("[data-radix-scroll-area-viewport]")
+              ?.scrollTo(0, 0);
+          });
+          props.onValueChange?.(value);
+        }}
       />
       <Text
         variant="labelsTitleCase"


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/1696

Added most of our shortcuts to command panel.

## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
