### PR TITLE
fix: use generated descriptions for align-self property values

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/flex-child/flex-child.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/flex-child/flex-child.tsx
@@ -70,36 +70,32 @@ const FlexChildSectionAlign = () => {
         items={[
           {
             child: <SmallXIcon />,
-            description:
-              "The element's alignment is determined by its parent's align-items property.",
+            description: propertyDescriptions["alignSelf:auto"],
             value: "auto",
           },
           {
             child: <ASStartIcon />,
-            description:
-              "The element is aligned at the start of the cross axis.",
+            description: propertyDescriptions["alignSelf:flex-start"],
             value: "flex-start",
           },
           {
             child: <ASEndIcon />,
-            description: "The element is aligned at the end of the cross axis.",
+            description: propertyDescriptions["alignSelf:flex-end"],
             value: "flex-end",
           },
           {
             child: <ASCenterIcon />,
-            description: "The element is centered along the cross axis.",
+            description: propertyDescriptions["alignSelf:center"],
             value: "center",
           },
           {
             child: <ASStretchIcon />,
-            description:
-              "The element is stretched to fill the entire cross axis.",
+            description: propertyDescriptions["alignSelf:stretch"],
             value: "stretch",
           },
           {
             child: <ASBaselineIcon />,
-            description:
-              "The element is aligned to the baseline of the parent.",
+            description: propertyDescriptions["alignSelf:baseline"],
             value: "baseline",
           },
         ]}


### PR DESCRIPTION
## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
